### PR TITLE
Benutzer, Buchungen und Urlaub generieren

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Created by https://www.gitignore.io/api/eclipse,intellij+all
 # Edit at https://www.gitignore.io/?templates=eclipse,intellij+all
 
+keycloak-9.0.2.tar.gz
 keycloak-9.0.2/
 
 ### Eclipse ###

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 5. Keycloak config importieren (`kcadm.bat`/`kcadm.sh` befinden sich im `bin/` Ordner von Keycloak):
     * Admin CLI anmelden: `.\kcadm.bat config credentials --server http://localhost:8080/auth --realm master --user <USERNAME> --password <PASSWORD>`
     * Realm importieren (keycloak_config.json im Projektordner): `.\kcadm.bat create realms -f "<PATH-TO-CONFIG>"`
+    6. In der Keycloak-Admin-Konsole im Master-Realm unter Realm-Settings -> Tokens die "Access Token Lifespan" auf 30 Minuten erhöhen
 
 ### H2 In-memory Datenbank
 

--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ Zugriff auf die Konsole auf [localhost:8081/h2-console](localhost:8081/h2-consol
 
 ### Keycloak API Zugriff
 
-1. Datei `application-keycloak.template` in `application-keycloak.yml` umbenennen
+1. Datei `application-keycloak.template` duplizieren und Duplikat in `application-keycloak.yml` umbenennen
 2. Username und Passwort des Keycloak Admins eintragen
+3. Beim Start des Servers: `keycloak` als Profil übergeben (Syntax analog wie bei Profil `h2`)

--- a/keycloak_config.json
+++ b/keycloak_config.json
@@ -1,7 +1,7 @@
 {
   "id": "badenair",
   "realm": "badenair",
-  "notBefore": 0,
+  "notBefore": 1587312531,
   "revokeRefreshToken": false,
   "refreshTokenMaxReuse": 0,
   "accessTokenLifespan": 300,
@@ -20,7 +20,7 @@
   "actionTokenGeneratedByUserLifespan": 300,
   "enabled": true,
   "sslRequired": "external",
-  "registrationAllowed": false,
+  "registrationAllowed": true,
   "registrationEmailAsUsername": false,
   "rememberMe": true,
   "verifyEmail": false,
@@ -410,6 +410,7 @@
   "groups": [],
   "defaultRoles": [
     "uma_authorization",
+    "badenair_customer",
     "offline_access"
   ],
   "requiredCredentials": [
@@ -1026,6 +1027,7 @@
           "consentRequired": false,
           "config": {
             "multivalued": "true",
+            "userinfo.token.claim": "true",
             "user.attribute": "foo",
             "id.token.claim": "true",
             "access.token.claim": "true",
@@ -1419,16 +1421,16 @@
     }
   ],
   "defaultDefaultClientScopes": [
-    "role_list",
     "profile",
-    "email",
+    "role_list",
+    "web-origins",
     "roles",
-    "web-origins"
+    "email"
   ],
   "defaultOptionalClientScopes": [
-    "offline_access",
-    "address",
     "phone",
+    "address",
+    "offline_access",
     "microprofile-jwt"
   ],
   "browserSecurityHeaders": {
@@ -1513,14 +1515,14 @@
         "subComponents": {},
         "config": {
           "allowed-protocol-mapper-types": [
-            "saml-user-attribute-mapper",
-            "oidc-sha256-pairwise-sub-mapper",
             "saml-role-list-mapper",
-            "oidc-address-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
             "saml-user-property-mapper",
-            "oidc-usermodel-property-mapper",
+            "saml-user-attribute-mapper",
             "oidc-full-name-mapper",
-            "oidc-usermodel-attribute-mapper"
+            "oidc-usermodel-property-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-address-mapper"
           ]
         }
       },
@@ -1544,14 +1546,14 @@
         "subComponents": {},
         "config": {
           "allowed-protocol-mapper-types": [
-            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-address-mapper",
+            "oidc-usermodel-attribute-mapper",
             "saml-user-property-mapper",
             "saml-role-list-mapper",
-            "oidc-usermodel-property-mapper",
-            "oidc-usermodel-attribute-mapper",
             "saml-user-attribute-mapper",
             "oidc-full-name-mapper",
-            "oidc-address-mapper"
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-property-mapper"
           ]
         }
       }
@@ -1599,7 +1601,7 @@
   "supportedLocales": [],
   "authenticationFlows": [
     {
-      "id": "7b41aabf-703b-4c6d-a770-499f1660643b",
+      "id": "ca0e7aab-80a7-4be8-8d8e-6fa87b9f7532",
       "alias": "Account verification options",
       "description": "Method with which to verity the existing account",
       "providerId": "basic-flow",
@@ -1623,7 +1625,7 @@
       ]
     },
     {
-      "id": "eeb9a080-688c-4574-bb03-67325cc26f2b",
+      "id": "7cb1aee0-b2e4-49fa-bcdc-dd6fa5f02371",
       "alias": "Authentication Options",
       "description": "Authentication options.",
       "providerId": "basic-flow",
@@ -1654,7 +1656,7 @@
       ]
     },
     {
-      "id": "836a7c8d-43c5-48af-9a6b-f93e896c6fe8",
+      "id": "e14a9182-d9c8-448f-847a-53be9a9790e7",
       "alias": "Browser - Conditional OTP",
       "description": "Flow to determine if the OTP is required for the authentication",
       "providerId": "basic-flow",
@@ -1678,7 +1680,7 @@
       ]
     },
     {
-      "id": "416bbdf1-ad1c-49eb-88d8-3297b8ed5acf",
+      "id": "264820be-1401-467a-a04e-5c75db1517b3",
       "alias": "Direct Grant - Conditional OTP",
       "description": "Flow to determine if the OTP is required for the authentication",
       "providerId": "basic-flow",
@@ -1702,7 +1704,7 @@
       ]
     },
     {
-      "id": "ecbf3fd4-1ed4-4cdc-9232-3fff0d4b2825",
+      "id": "17fc52aa-56b2-4b60-b3cb-9bf1e2bbc674",
       "alias": "First broker login - Conditional OTP",
       "description": "Flow to determine if the OTP is required for the authentication",
       "providerId": "basic-flow",
@@ -1726,7 +1728,7 @@
       ]
     },
     {
-      "id": "1f45f89a-afc7-4229-b8c9-02870e1f365a",
+      "id": "390c6e44-7bfc-419a-b0bd-ad8e93840ecf",
       "alias": "Handle Existing Account",
       "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
       "providerId": "basic-flow",
@@ -1750,7 +1752,7 @@
       ]
     },
     {
-      "id": "7f9c16d3-d786-400f-81d4-6af870f1e71d",
+      "id": "3b91af05-8517-46e0-89a8-cd399b6f57fe",
       "alias": "Reset - Conditional OTP",
       "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
       "providerId": "basic-flow",
@@ -1774,7 +1776,7 @@
       ]
     },
     {
-      "id": "ad530abe-6aff-4beb-88a0-2552738cf5c7",
+      "id": "c6a61812-990b-4f2c-b9b5-48068aa8533b",
       "alias": "User creation or linking",
       "description": "Flow for the existing/non-existing user alternatives",
       "providerId": "basic-flow",
@@ -1799,7 +1801,7 @@
       ]
     },
     {
-      "id": "f6bd8120-5615-4803-bc77-79379cf4f572",
+      "id": "3de6eb63-d05c-4cee-9b7f-cea14227c16c",
       "alias": "Verify Existing Account by Re-authentication",
       "description": "Reauthentication of existing account",
       "providerId": "basic-flow",
@@ -1823,7 +1825,7 @@
       ]
     },
     {
-      "id": "6f9f955a-79f8-4921-b488-c6449d38f32b",
+      "id": "82861227-0b36-426d-9843-8b250aaee226",
       "alias": "browser",
       "description": "browser based authentication",
       "providerId": "basic-flow",
@@ -1861,7 +1863,7 @@
       ]
     },
     {
-      "id": "4063a3f9-23b1-4840-a9b5-b4f7f25925e2",
+      "id": "ce921246-0028-44f8-8563-0e4667523ac1",
       "alias": "clients",
       "description": "Base authentication for clients",
       "providerId": "client-flow",
@@ -1899,7 +1901,7 @@
       ]
     },
     {
-      "id": "ee07b38d-3e06-482e-be97-9e209ea08b6b",
+      "id": "22634109-96ee-4e71-a412-5e63badbb472",
       "alias": "direct grant",
       "description": "OpenID Connect Resource Owner Grant",
       "providerId": "basic-flow",
@@ -1930,7 +1932,7 @@
       ]
     },
     {
-      "id": "c1ce83ac-69f6-4f77-9a82-e52fae115f73",
+      "id": "06c2ca1b-50cc-44c0-9cd0-eed8974e8b4f",
       "alias": "docker auth",
       "description": "Used by Docker clients to authenticate against the IDP",
       "providerId": "basic-flow",
@@ -1947,7 +1949,7 @@
       ]
     },
     {
-      "id": "fb434539-a1d6-4c14-82d2-a1c742ae2ec2",
+      "id": "cd24b534-9e79-4b99-9a7d-d52ee3607c48",
       "alias": "first broker login",
       "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
       "providerId": "basic-flow",
@@ -1972,7 +1974,7 @@
       ]
     },
     {
-      "id": "86e490a9-49a9-4edd-a3c1-68498b2281d5",
+      "id": "8413a03b-4a83-45e7-9a0e-19c8cd509c39",
       "alias": "forms",
       "description": "Username, password, otp and other auth forms.",
       "providerId": "basic-flow",
@@ -1996,7 +1998,7 @@
       ]
     },
     {
-      "id": "174bee56-6049-4ec0-8543-1d1e5df5544c",
+      "id": "8527d478-8c79-450a-a54d-5b76bea9a82f",
       "alias": "http challenge",
       "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
       "providerId": "basic-flow",
@@ -2020,7 +2022,7 @@
       ]
     },
     {
-      "id": "d4aad964-b99c-427b-9367-f37a9b8dec95",
+      "id": "bc46c65a-f346-4fdf-b928-e15f8ed4c63e",
       "alias": "registration",
       "description": "registration flow",
       "providerId": "basic-flow",
@@ -2038,7 +2040,7 @@
       ]
     },
     {
-      "id": "0f5a5ad9-ed07-4768-a280-f7f568a93682",
+      "id": "9eacb287-4a98-4f38-b13d-cd2cb4e8932d",
       "alias": "registration form",
       "description": "registration form",
       "providerId": "form-flow",
@@ -2076,7 +2078,7 @@
       ]
     },
     {
-      "id": "0a8efa3e-33b2-414d-8f07-5c0bb38198dd",
+      "id": "e40b171a-b7a0-4e38-aa37-e9c0abd9b310",
       "alias": "reset credentials",
       "description": "Reset credentials for a user if they forgot their password or something",
       "providerId": "basic-flow",
@@ -2114,7 +2116,7 @@
       ]
     },
     {
-      "id": "44855619-505c-4b85-90ba-4982c2e5e5fc",
+      "id": "a42a61ce-1193-4a24-8897-efe9b984d508",
       "alias": "saml ecp",
       "description": "SAML ECP Profile Authentication Flow",
       "providerId": "basic-flow",
@@ -2133,14 +2135,14 @@
   ],
   "authenticatorConfig": [
     {
-      "id": "000c3f0e-3c41-4a8b-9772-c8b88a72f88f",
+      "id": "5f171e0d-919d-4951-b961-53c6b82414d3",
       "alias": "create unique user config",
       "config": {
         "require.password.update.after.registration": "false"
       }
     },
     {
-      "id": "4507e24d-fe1f-4105-b355-991a6a35da5c",
+      "id": "86523818-e3f2-4a34-9bdc-7e85896d9d42",
       "alias": "review profile config",
       "config": {
         "update.profile.on.first.login": "missing"

--- a/keycloak_import.sh
+++ b/keycloak_import.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+cd keycloak-9.0.2/bin
+bash kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user admin --password admin
+bash kcadm.sh create realms -f ../../keycloak_config.json

--- a/keycloak_setup.sh
+++ b/keycloak_setup.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+rm -r keycloak-9.0.2
+tar -xzf keycloak-9.0.2.tar.gz
+cd keycloak-9.0.2/bin
+bash standalone.sh -b 0.0.0.0

--- a/server/src/main/java/de/hso/badenair/service/flight/booking/BookingService.java
+++ b/server/src/main/java/de/hso/badenair/service/flight/booking/BookingService.java
@@ -13,6 +13,7 @@ import de.hso.badenair.service.booking.repository.BookingRepository;
 import de.hso.badenair.service.flight.FlightService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
 import java.util.List;
@@ -26,6 +27,7 @@ public class BookingService {
 
 	private final List<Integer> allowedWeights = List.of(15, 23, 30);
 
+	@Transactional
 	public boolean bookFlight(String username, IncomingBookingDto dto) {
 		Flight flight = flightService.getFlightById(dto.getFlightId());
 		if (flight != null) {

--- a/server/src/main/java/de/hso/badenair/service/flight/booking/BookingService.java
+++ b/server/src/main/java/de/hso/badenair/service/flight/booking/BookingService.java
@@ -21,20 +21,21 @@ import java.util.Set;
 @Service
 @RequiredArgsConstructor
 public class BookingService {
-    private final BookingRepository bookingRepository;
-    private final FlightService flightService;
+	private final BookingRepository bookingRepository;
+	private final FlightService flightService;
 
-    private final List<Integer> allowedWeights = List.of(15, 23, 30);
+	private final List<Integer> allowedWeights = List.of(15, 23, 30);
 
-    public boolean bookFlight(String username, IncomingBookingDto dto) {
-        Flight flight = flightService.getFlightById(dto.getFlightId());
-        if (flight != null) {
-            Set<Traveler> travelers = new HashSet<>();
-            Booking newBooking = Booking.builder().flight(flight)
-                .customerUserId(username).build();
+	public boolean bookFlight(String username, IncomingBookingDto dto) {
+		Flight flight = flightService.getFlightById(dto.getFlightId());
+		if (flight != null) {
+			Set<Traveler> travelers = new HashSet<>();
+			Booking newBooking = Booking.builder().flight(flight)
+					.customerUserId(username).build();
 
-            for (int i = 0; i < dto.getPassengers().length; i++) {
-                IncomingTravelerDto travelerDto = dto.getPassengers()[i];
+			for (int i = 0; i < dto.getPassengers().length; i++) {
+				IncomingTravelerDto travelerDto = dto.getPassengers()[i];
+				// TODO: check if seat is available (reject booking otherwise)
 				SelectedSeatDto selectedSeat = dto.getSeats()[i];
 				Traveler traveler = Traveler.builder()
                     .firstName(travelerDto.getName())
@@ -47,45 +48,45 @@ public class BookingService {
                 travelers.add(traveler);
 
                 Set<Luggage> luggages = new HashSet<>();
-                if (allowedWeights.contains(travelerDto.getBaggage1())) {
-                    Luggage luggage1 = Luggage.builder()
-                        .state(LuggageState.AT_TRAVELLER)
-                        .weight(travelerDto.getBaggage1())
-                        .traveler(traveler).build();
-                    luggages.add(luggage1);
-                }
+				if (allowedWeights.contains(travelerDto.getBaggage1())) {
+					Luggage luggage1 = Luggage.builder()
+							.state(LuggageState.AT_TRAVELLER)
+							.weight(travelerDto.getBaggage1())
+							.traveler(traveler).build();
+					luggages.add(luggage1);
+				}
 
-                if (allowedWeights.contains(travelerDto.getBaggage2())) {
-                    Luggage luggage2 = Luggage.builder()
-                        .state(LuggageState.AT_TRAVELLER)
-                        .weight(travelerDto.getBaggage2())
-                        .traveler(traveler).build();
-                    luggages.add(luggage2);
-                }
-                if (allowedWeights.contains(travelerDto.getBaggage3())) {
-                    Luggage luggage3 = Luggage.builder()
-                        .state(LuggageState.AT_TRAVELLER)
-                        .weight(travelerDto.getBaggage3())
-                        .traveler(traveler).build();
-                    luggages.add(luggage3);
-                }
-                if (allowedWeights.contains(travelerDto.getBaggage4())) {
-                    Luggage luggage4 = Luggage.builder()
-                        .state(LuggageState.AT_TRAVELLER)
-                        .weight(travelerDto.getBaggage4())
-                        .traveler(traveler).build();
-                    luggages.add(luggage4);
-                }
-                if (!luggages.isEmpty()) {
-                    traveler.setLuggage(luggages);
-                }
-            }
+				if (allowedWeights.contains(travelerDto.getBaggage2())) {
+					Luggage luggage2 = Luggage.builder()
+							.state(LuggageState.AT_TRAVELLER)
+							.weight(travelerDto.getBaggage2())
+							.traveler(traveler).build();
+					luggages.add(luggage2);
+				}
+				if (allowedWeights.contains(travelerDto.getBaggage3())) {
+					Luggage luggage3 = Luggage.builder()
+							.state(LuggageState.AT_TRAVELLER)
+							.weight(travelerDto.getBaggage3())
+							.traveler(traveler).build();
+					luggages.add(luggage3);
+				}
+				if (allowedWeights.contains(travelerDto.getBaggage4())) {
+					Luggage luggage4 = Luggage.builder()
+							.state(LuggageState.AT_TRAVELLER)
+							.weight(travelerDto.getBaggage4())
+							.traveler(traveler).build();
+					luggages.add(luggage4);
+				}
+				if (!luggages.isEmpty()) {
+					traveler.setLuggage(luggages);
+				}
+			}
 			if (!travelers.isEmpty()) {
-                newBooking.setTravelers(travelers);
-                PriceCalculator.calculateFinalPrice(newBooking);
-                bookingRepository.save(newBooking);
-                return true;
-            }
+				newBooking.setTravelers(travelers);
+				PriceCalculator.calculateFinalPrice(newBooking);
+				bookingRepository.save(newBooking);
+				return true;
+			}
 		}
 
 		return false;

--- a/server/src/main/java/de/hso/badenair/service/keycloakapi/KeycloakApiService.java
+++ b/server/src/main/java/de/hso/badenair/service/keycloakapi/KeycloakApiService.java
@@ -35,6 +35,7 @@ public class KeycloakApiService {
     private final RestTemplate restTemplate = new RestTemplate();
     private String accessToken;
     private Map<EmployeeRole, RoleRepresentation> employeeRoles;
+    private RoleRepresentation customerRole;
 
     /**
      * Retrieves access token from the keyloak server with the given credentials
@@ -81,6 +82,8 @@ public class KeycloakApiService {
             final UserRepresentation userRepresentation = getUser(username)
                 .orElseThrow(() -> new UserNotFoundException(username));
             addRoleToUser(roles, userRepresentation.getId());
+            RoleRepresentation[] rolesToRemove = {customerRole};
+            removeRoleFromUser(rolesToRemove, userRepresentation.getId());
         } catch (HttpClientErrorException e) {
             log.warn("User {} could not be created: {}", username, e.getMessage());
         }
@@ -170,6 +173,9 @@ public class KeycloakApiService {
                 role -> EmployeeRole.fromString(role.getName()),
                 Function.identity()
             ));
+
+        customerRole = Arrays.stream(roles).filter(role -> role.getName().equals(CUSTOMER_ROLE_NAME))
+            .findFirst().orElseThrow(GetRolesException::new);
     }
 
     /**
@@ -201,6 +207,18 @@ public class KeycloakApiService {
 
         final String url = "http://" + config.getHost() + "/auth/admin/realms/badenair/users/" + userId + "/role-mappings/realm";
         restTemplate.exchange(url, HttpMethod.POST, entity, Void.class);
+    }
+
+    /**
+     * Removes the specified roles to the user
+     * @param roleRepresentations Roles the user will be given
+     * @param userId ID of the user
+     */
+    private void removeRoleFromUser(RoleRepresentation[] roleRepresentations, String userId) {
+        HttpEntity<RoleRepresentation[]> entity = new HttpEntity<>(roleRepresentations, getAuthHeader());
+
+        final String url = "http://" + config.getHost() + "/auth/admin/realms/badenair/users/" + userId + "/role-mappings/realm";
+        restTemplate.exchange(url, HttpMethod.DELETE, entity, Void.class);
     }
 
     /**

--- a/server/src/main/java/de/hso/badenair/service/keycloakapi/KeycloakApiService.java
+++ b/server/src/main/java/de/hso/badenair/service/keycloakapi/KeycloakApiService.java
@@ -112,7 +112,7 @@ public class KeycloakApiService {
     public List<UserRepresentation> getCustomerUsers() {
         HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(getAuthHeader());
 
-        final String url = getBaseUrl() + "roles/" + CUSTOMER_ROLE_NAME + "/users";
+        final String url = getBaseUrl() + "roles/" + CUSTOMER_ROLE_NAME + "/users?max=2000";
         final ResponseEntity<UserRepresentation[]> exchange = restTemplate.exchange(url, HttpMethod.GET, entity, UserRepresentation[].class);
 
         final UserRepresentation[] body = Optional.ofNullable(exchange.getBody()).orElse(EMPTY_USER_LIST);
@@ -126,7 +126,7 @@ public class KeycloakApiService {
     public List<UserRepresentation> getEmployeeUsers() {
         HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(getAuthHeader());
 
-        final String url = getBaseUrl() + "roles/" + EmployeeRole.DEFAULT.getName() + "/users";
+        final String url = getBaseUrl() + "roles/" + EmployeeRole.DEFAULT.getName() + "/users?max=1000";
         final ResponseEntity<UserRepresentation[]> exchange = restTemplate.exchange(url, HttpMethod.GET, entity, UserRepresentation[].class);
 
         final UserRepresentation[] body = Optional.ofNullable(exchange.getBody()).orElse(EMPTY_USER_LIST);

--- a/server/src/main/java/de/hso/badenair/service/plan/vacation/VacationService.java
+++ b/server/src/main/java/de/hso/badenair/service/plan/vacation/VacationService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
@@ -35,8 +36,8 @@ public class VacationService {
 
     @Transactional
     public void requestVacation(String employeeUserId, RequestVacationDto requestVacationDto) {
-        final OffsetDateTime startDate = requestVacationDto.getStartDate();
-        final OffsetDateTime endDate = requestVacationDto.getEndDate();
+        final OffsetDateTime startDate = requestVacationDto.getStartDate().withOffsetSameLocal(ZoneOffset.of("+1"));
+        final OffsetDateTime endDate = requestVacationDto.getEndDate().withOffsetSameLocal(ZoneOffset.of("+1"));
         final int differenceInDays = getDifferenceInDays(startDate, endDate);
 
         if (endDate.isBefore(startDate) || differenceInDays <= 0) {

--- a/server/src/main/java/de/hso/badenair/util/init/StaticDataInitializer.java
+++ b/server/src/main/java/de/hso/badenair/util/init/StaticDataInitializer.java
@@ -70,12 +70,14 @@ public class StaticDataInitializer {
 	private static final boolean DEMO_MODE = false;
 
 	/**
-	 * Defines the amount of customer accounts that will be created in the demo mode.
+	 * Defines the amount of customer accounts that will be created in the demo
+	 * mode.
 	 */
 	private static final int AMOUNT_OF_CUSTOMERS = 1040;
 
 	/**
-	 * Defines the amount of bookings that will be generated for a customer in the demo mode.
+	 * Defines the amount of bookings that will be generated for a customer in the
+	 * demo mode.
 	 */
 	private static final int BOOKINGS_PER_CUSTOMER = 349;
 
@@ -92,9 +94,9 @@ public class StaticDataInitializer {
 
 		initFlightplan();
 		// generateFlightplan();
-		
+
 		initEmployees();
-		
+
 		if (DEMO_MODE) {
 			initCustomers();
 			initBookings();
@@ -107,20 +109,17 @@ public class StaticDataInitializer {
 	 * Creates the available plane types in the database.
 	 */
 	private void initPlaneTypeData() {
-		final PlaneTypeData planeTypeDataDash_8_400 = PlaneTypeData.builder()
-				.type(PlaneType.Dash_8_400).numberOfPassengers(76)
-				.numberOfRows(19).numberOfColumns(4).flightRange(1000).build();
+		final PlaneTypeData planeTypeDataDash_8_400 = PlaneTypeData.builder().type(PlaneType.Dash_8_400)
+				.numberOfPassengers(76).numberOfRows(19).numberOfColumns(4).flightRange(1000).build();
 
-		final PlaneTypeData planeTypeDataDash_8_200 = PlaneTypeData.builder()
-				.type(PlaneType.Dash_8_200).numberOfPassengers(36)
-				.numberOfRows(9).numberOfColumns(4).flightRange(1000).build();
+		final PlaneTypeData planeTypeDataDash_8_200 = PlaneTypeData.builder().type(PlaneType.Dash_8_200)
+				.numberOfPassengers(36).numberOfRows(9).numberOfColumns(4).flightRange(1000).build();
 
-		final PlaneTypeData planeTypeDataB737_400 = PlaneTypeData.builder()
-				.type(PlaneType.B737_400).numberOfPassengers(186)
-				.numberOfRows(31).numberOfColumns(6).flightRange(2500).build();
+		final PlaneTypeData planeTypeDataB737_400 = PlaneTypeData.builder().type(PlaneType.B737_400)
+				.numberOfPassengers(186).numberOfRows(31).numberOfColumns(6).flightRange(2500).build();
 
-		planeTypeDataRepository.saveAll(List.of(planeTypeDataDash_8_400,
-				planeTypeDataDash_8_200, planeTypeDataB737_400));
+		planeTypeDataRepository
+				.saveAll(List.of(planeTypeDataDash_8_400, planeTypeDataDash_8_200, planeTypeDataB737_400));
 	}
 
 	/**
@@ -128,12 +127,9 @@ public class StaticDataInitializer {
 	 */
 	private void initPlanes() {
 		// Get types
-		PlaneTypeData planeTypeDataDash_8_200 = planeTypeDataRepository
-				.findAllByType(PlaneType.Dash_8_200).get(0);
-		PlaneTypeData planeTypeDataDash_8_400 = planeTypeDataRepository
-				.findAllByType(PlaneType.Dash_8_400).get(0);
-		PlaneTypeData planeTypeDataB737_400 = planeTypeDataRepository
-				.findAllByType(PlaneType.B737_400).get(0);
+		PlaneTypeData planeTypeDataDash_8_200 = planeTypeDataRepository.findAllByType(PlaneType.Dash_8_200).get(0);
+		PlaneTypeData planeTypeDataDash_8_400 = planeTypeDataRepository.findAllByType(PlaneType.Dash_8_400).get(0);
+		PlaneTypeData planeTypeDataB737_400 = planeTypeDataRepository.findAllByType(PlaneType.B737_400).get(0);
 
 		List<Plane> planes = new ArrayList<Plane>();
 
@@ -144,18 +140,18 @@ public class StaticDataInitializer {
 
 		// Create planes
 		for (int i = 0; i < dash_8_200_count; i++) {
-			planes.add(Plane.builder().typeData(planeTypeDataDash_8_200)
-					.state(PlaneState.WAITING).traveledDistance(0).build());
+			planes.add(Plane.builder().typeData(planeTypeDataDash_8_200).state(PlaneState.WAITING).traveledDistance(0)
+					.build());
 		}
 
 		for (int i = 0; i < dash_8_400_count; i++) {
-			planes.add(Plane.builder().typeData(planeTypeDataDash_8_400)
-					.state(PlaneState.WAITING).traveledDistance(0).build());
+			planes.add(Plane.builder().typeData(planeTypeDataDash_8_400).state(PlaneState.WAITING).traveledDistance(0)
+					.build());
 		}
 
 		for (int i = 0; i < b737_400_count; i++) {
-			planes.add(Plane.builder().typeData(planeTypeDataB737_400)
-					.state(PlaneState.WAITING).traveledDistance(0).build());
+			planes.add(Plane.builder().typeData(planeTypeDataB737_400).state(PlaneState.WAITING).traveledDistance(0)
+					.build());
 		}
 
 		planeRepository.saveAll(planes);
@@ -168,14 +164,12 @@ public class StaticDataInitializer {
 		List<Airport> airports = new ArrayList<Airport>();
 
 		try {
-			List<String[]> data = CsvHelper.getData(
-					ResourceUtils.getFile("classpath:data/airports.csv"));
+			List<String[]> data = CsvHelper.getData(ResourceUtils.getFile("classpath:data/airports.csv"));
 
 			// Get all (valid) airports
 			for (String[] airportData : data) {
 				if (airportData.length == 3) {
-					airports.add(Airport.builder().name(airportData[0])
-							.distance(Integer.valueOf(airportData[1]))
+					airports.add(Airport.builder().name(airportData[0]).distance(Integer.valueOf(airportData[1]))
 							.timezone(airportData[2]).build());
 				}
 			}
@@ -187,14 +181,17 @@ public class StaticDataInitializer {
 	}
 
 	/**
-	 * Initializes the flightplan data according to the file "flightplan.csv".
-	 * If {@link DEMO_MODE} is set, a more dense flightplan will be used.
+	 * Initializes the flightplan data according to the file "flightplan.csv". If
+	 * {@link DEMO_MODE} is set, a more dense flightplan will be used.
 	 */
 	private void initFlightplan() {
 		// Get planes
 		List<Plane> initialPlanes = new LinkedList<Plane>();
 		planeRepository.findAll().forEach(initialPlanes::add);
 		HashMap<String, Plane> mappedPlanes = new HashMap<String, Plane>();
+
+		List<ScheduledFlight> scheduledFlights = new ArrayList<>();
+		List<Flight> flights = new ArrayList<>();
 
 		// Demo mode: adjusted flightplan
 		String flightplanFile;
@@ -205,8 +202,7 @@ public class StaticDataInitializer {
 		}
 
 		try {
-			List<String[]> data = CsvHelper.getData(
-					ResourceUtils.getFile("classpath:data/" + flightplanFile));
+			List<String[]> data = CsvHelper.getData(ResourceUtils.getFile("classpath:data/" + flightplanFile));
 
 			// Map ids of planes (in case they change)
 			for (String[] flightData : data) {
@@ -218,8 +214,7 @@ public class StaticDataInitializer {
 
 					// Find unmapped plane
 					for (Plane plane : initialPlanes) {
-						if (plane.getTypeData().getType().getName()
-								.equals(flightData[6])) {
+						if (plane.getTypeData().getType().getName().equals(flightData[6])) {
 							mappedPlanes.put(flightData[7], plane);
 						}
 					}
@@ -228,46 +223,38 @@ public class StaticDataInitializer {
 			}
 
 			// Dates stored for consistency
-			OffsetDateTime now = OffsetDateTime.now()
-					.withOffsetSameLocal(ZoneOffset.of("+1"));
+			OffsetDateTime now = OffsetDateTime.now().withOffsetSameLocal(ZoneOffset.of("+1"));
 			OffsetDateTime endOfPlanDate = now.plusMonths(12l);
 
 			// Get all (valid) scheduled flights
 			for (String[] flightData : data) {
 				if (flightData.length == 8) {
-					int hour = Integer.valueOf(flightData[4].substring(0,
-							flightData[4].indexOf(":")));
-					int minute = Integer.valueOf(flightData[4]
-							.substring(flightData[4].indexOf(":") + 1));
+					int hour = Integer.valueOf(flightData[4].substring(0, flightData[4].indexOf(":")));
+					int minute = Integer.valueOf(flightData[4].substring(flightData[4].indexOf(":") + 1));
 
 					ScheduledFlight scheduledFlight = ScheduledFlight.builder()
-							.startingAirport(airportRepository
-									.findByName(flightData[0]).get())
-							.destinationAirport(airportRepository
-									.findByName(flightData[1]).get())
-							.basePrice(Double.valueOf(flightData[2]))
-							.durationInHours(Double.valueOf(flightData[3]))
-							.startTime(now.withHour(hour).withMinute(minute))
-							.build();
-					scheduledFlightRepository.save(scheduledFlight);
+							.startingAirport(airportRepository.findByName(flightData[0]).get())
+							.destinationAirport(airportRepository.findByName(flightData[1]).get())
+							.basePrice(Double.valueOf(flightData[2])).durationInHours(Double.valueOf(flightData[3]))
+							.startTime(now.withHour(hour).withMinute(minute)).build();
+					scheduledFlights.add(scheduledFlight);
 
 					Plane plane = mappedPlanes.get(flightData[7]);
 
 					OffsetDateTime startDate = now
-							.plusDays(Math.floorMod(
-									Integer.valueOf(flightData[5])
-											- now.getDayOfWeek().getValue(),
-									7));
+							.plusDays(Math.floorMod(Integer.valueOf(flightData[5]) - now.getDayOfWeek().getValue(), 7));
 					do {
 						// Add flights for the next 12 months
-						flightRepository.save(Flight.builder()
-								.scheduledFlight(scheduledFlight)
-								.state(FlightState.OK).plane(plane)
+						flights.add(Flight.builder().scheduledFlight(scheduledFlight).state(FlightState.OK).plane(plane)
 								.startDate(startDate).build());
 						startDate = startDate.plusDays(7l);
 					} while (startDate.isBefore(endOfPlanDate));
 				}
 			}
+
+			// Save to database
+			scheduledFlightRepository.saveAll(scheduledFlights);
+			flightRepository.saveAll(flights);
 		} catch (FileNotFoundException e) {
 			e.printStackTrace();
 		}
@@ -288,11 +275,10 @@ public class StaticDataInitializer {
 	 * customer. (This method shall be used solely for the demo mode.)
 	 */
 	private void initBookings() {
-		List<UserRepresentation> customers = keycloakApiService
-				.getCustomerUsers();
+		List<UserRepresentation> customers = keycloakApiService.getCustomerUsers();
 		List<Flight> flights = new ArrayList<>();
 		flightRepository.findAll().forEach(flights::add);
-		final int[] baggageWeights = {0, 15, 23, 30};
+		final int[] baggageWeights = { 0, 15, 23, 30 };
 
 		Random random = new Random(444);
 		for (UserRepresentation customer : customers) {
@@ -301,31 +287,22 @@ public class StaticDataInitializer {
 				Flight flight = flights.get(random.nextInt(flights.size()));
 
 				// Create travelers
-				IncomingTravelerDto[] travelers = new IncomingTravelerDto[random
-						.nextInt(12) + 1];
+				IncomingTravelerDto[] travelers = new IncomingTravelerDto[random.nextInt(12) + 1];
 				SelectedSeatDto[] selectedSeats = new SelectedSeatDto[travelers.length];
 				for (int j = 0; j < travelers.length; j++) {
-					travelers[j] = new IncomingTravelerDto("Max", "Mustermann",
-							false,
-							baggageWeights[random
-									.nextInt(baggageWeights.length)],
-							baggageWeights[random
-									.nextInt(baggageWeights.length)],
-							baggageWeights[random
-									.nextInt(baggageWeights.length)],
-							baggageWeights[random
-									.nextInt(baggageWeights.length)]);
+					travelers[j] = new IncomingTravelerDto("Max", "Mustermann", false,
+							baggageWeights[random.nextInt(baggageWeights.length)],
+							baggageWeights[random.nextInt(baggageWeights.length)],
+							baggageWeights[random.nextInt(baggageWeights.length)],
+							baggageWeights[random.nextInt(baggageWeights.length)]);
 					selectedSeats[j] = new SelectedSeatDto(
-							random.nextInt(flight.getPlane().getTypeData()
-									.getNumberOfRows()),
-							random.nextInt(flight.getPlane().getTypeData()
-									.getNumberOfColumns()));
+							random.nextInt(flight.getPlane().getTypeData().getNumberOfRows()),
+							random.nextInt(flight.getPlane().getTypeData().getNumberOfColumns()));
 				}
 
 				// Try to book the flight (may fail if seat is already taken by
 				// another traveler)
-				IncomingBookingDto booking = new IncomingBookingDto(
-						flight.getId(), travelers, selectedSeats, 0.0);
+				IncomingBookingDto booking = new IncomingBookingDto(flight.getId(), travelers, selectedSeats, 0.0);
 				bookingService.bookFlight(customer.getId(), booking);
 			}
 		}
@@ -338,29 +315,24 @@ public class StaticDataInitializer {
 		// Pilots
 		// TODO: differentiate dash and jet pilots
 		for (int i = 0; i < 40; i++) {
-			keycloakApiService.createEmployeeUser("dashpilot" + (i + 1),
-					EmployeeRole.PILOT);
+			keycloakApiService.createEmployeeUser("dashpilot" + (i + 1), EmployeeRole.PILOT);
 		}
 		for (int i = 0; i < 10; i++) {
-			keycloakApiService.createEmployeeUser("jetpilot" + (i + 1),
-					EmployeeRole.PILOT);
+			keycloakApiService.createEmployeeUser("jetpilot" + (i + 1), EmployeeRole.PILOT);
 		}
 
 		// Cabin crew
 		// TODO: add cabin crew role
 		for (int i = 0; i < 200; i++) {
-			keycloakApiService.createEmployeeUser("cabin" + (i + 1),
-					EmployeeRole.DEFAULT);
+			keycloakApiService.createEmployeeUser("cabin" + (i + 1), EmployeeRole.DEFAULT);
 		}
 
 		for (int i = 0; i < 30; i++) {
-			keycloakApiService.createEmployeeUser("technician" + (i + 1),
-					EmployeeRole.TECHNICIAN);
+			keycloakApiService.createEmployeeUser("technician" + (i + 1), EmployeeRole.TECHNICIAN);
 		}
 
 		for (int i = 0; i < 20; i++) {
-			keycloakApiService.createEmployeeUser("ground" + (i + 1),
-					EmployeeRole.GROUND);
+			keycloakApiService.createEmployeeUser("ground" + (i + 1), EmployeeRole.GROUND);
 		}
 	}
 
@@ -368,18 +340,14 @@ public class StaticDataInitializer {
 	 * Requests a vacation for every employee.
 	 */
 	private void initVacation() {
-		List<UserRepresentation> employees = keycloakApiService
-				.getEmployeeUsers();
+		List<UserRepresentation> employees = keycloakApiService.getEmployeeUsers();
 		Random random = new Random(42);
 
 		for (UserRepresentation employee : employees) {
 			int offsetInDays = random.nextInt(340) + 1;
-			RequestVacationDto requestVacationDto = new RequestVacationDto(
-					OffsetDateTime.now().plusDays(offsetInDays),
-					OffsetDateTime.now()
-							.plusDays(offsetInDays + random.nextInt(14) + 1));
-			vacationService.requestVacation(employee.getUsername(),
-					requestVacationDto);
+			RequestVacationDto requestVacationDto = new RequestVacationDto(OffsetDateTime.now().plusDays(offsetInDays),
+					OffsetDateTime.now().plusDays(offsetInDays + random.nextInt(14) + 1));
+			vacationService.requestVacation(employee.getUsername(), requestVacationDto);
 		}
 	}
 

--- a/server/src/main/java/de/hso/badenair/util/init/StaticDataInitializer.java
+++ b/server/src/main/java/de/hso/badenair/util/init/StaticDataInitializer.java
@@ -11,6 +11,7 @@ import java.util.Random;
 
 import javax.annotation.PostConstruct;
 
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ResourceUtils;
 
@@ -39,8 +40,12 @@ import de.hso.badenair.service.plane.repository.PlaneTypeDataRepository;
 import de.hso.badenair.util.csv.CsvHelper;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * Performs various data initialization tasks.
+ */
 @Component
 @RequiredArgsConstructor
+@DependsOn("keycloakApiService")
 public class StaticDataInitializer {
 
 	private final PlaneTypeDataRepository planeTypeDataRepository;
@@ -59,10 +64,19 @@ public class StaticDataInitializer {
 
 	private final VacationService vacationService;
 
-	private static final boolean DEMO_MODE = false;
+	/**
+	 * If set to true, demo mode will be enabled.
+	 */
+	private static final boolean DEMO_MODE = true;
 
+	/**
+	 * Defines the amount of customer accounts that will be created in the demo mode.
+	 */
 	private static final int AMOUNT_OF_CUSTOMERS = 1040;
 
+	/**
+	 * Defines the amount of bookings that will be generated for a customer in the demo mode.
+	 */
 	private static final int BOOKINGS_PER_CUSTOMER = 349;
 
 	/**
@@ -78,12 +92,13 @@ public class StaticDataInitializer {
 
 		initFlightplan();
 		// generateFlightplan();
-
+		
+		initEmployees();
+		
 		if (DEMO_MODE) {
 			initCustomers();
 			initBookings();
 
-			initEmployees();
 			initVacation();
 		}
 	}
@@ -311,7 +326,7 @@ public class StaticDataInitializer {
 				// another traveler)
 				IncomingBookingDto booking = new IncomingBookingDto(
 						flight.getId(), travelers, selectedSeats, 0.0);
-				bookingService.bookFlight(customer.getUsername(), booking);
+				bookingService.bookFlight(customer.getId(), booking);
 			}
 		}
 	}

--- a/server/src/main/java/de/hso/badenair/util/init/StaticDataInitializer.java
+++ b/server/src/main/java/de/hso/badenair/util/init/StaticDataInitializer.java
@@ -67,7 +67,7 @@ public class StaticDataInitializer {
 	/**
 	 * If set to true, demo mode will be enabled.
 	 */
-	private static final boolean DEMO_MODE = true;
+	private static final boolean DEMO_MODE = false;
 
 	/**
 	 * Defines the amount of customer accounts that will be created in the demo mode.

--- a/server/src/main/java/de/hso/badenair/util/init/StaticDataInitializer.java
+++ b/server/src/main/java/de/hso/badenair/util/init/StaticDataInitializer.java
@@ -208,7 +208,7 @@ public class StaticDataInitializer {
 							mappedPlanes.put(flightData[7], plane);
 						}
 					}
-					initialPlanes.remove(flightData[7]);
+					initialPlanes.remove(mappedPlanes.get(flightData[7]));
 				}
 			}
 


### PR DESCRIPTION
Hiermit werden beim Start alle vom Lastenheft geforderten Employee-Accounts angelegt. (Muss später noch angepasst werden. Siehe #126)
Im Demo-Modus werden außerdem 1040 Kunden-Accounts mit jeweils 349 zufälligen Buchungen angelegt (Sobald #127 erledigt ist, werden vermutlich einige Buchungen fehlschlagen. Für Demo-Zwecke ist das aber nicht relevant).
Für die Mitarbeiter wird im Demo-Modus außerdem noch zufälliger Urlaub angefordert.