### PR TITLE
Korrekte Datenbank-Zeitzone

### DIFF
--- a/server/src/main/java/de/hso/badenair/domain/flight/Flight.java
+++ b/server/src/main/java/de/hso/badenair/domain/flight/Flight.java
@@ -1,6 +1,7 @@
 package de.hso.badenair.domain.flight;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Set;
 
 import javax.persistence.CascadeType;
@@ -63,4 +64,25 @@ public class Flight extends BaseEntity {
 
 	@OneToMany(mappedBy = "flight", cascade = CascadeType.ALL, orphanRemoval = true)
 	private Set<Booking> bookings;
+
+	public OffsetDateTime getStartDate() {
+		if (startDate == null) {
+			return null;
+		}
+		return startDate.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
+
+	public OffsetDateTime getActualStartTime() {
+		if (actualStartTime == null) {
+			return null;
+		}
+		return actualStartTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
+
+	public OffsetDateTime getActualLandingTime() {
+		if (actualLandingTime == null) {
+			return null;
+		}
+		return actualLandingTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
 }

--- a/server/src/main/java/de/hso/badenair/domain/flight/ScheduledFlight.java
+++ b/server/src/main/java/de/hso/badenair/domain/flight/ScheduledFlight.java
@@ -1,10 +1,24 @@
 package de.hso.badenair.domain.flight;
 
-import de.hso.badenair.domain.base.BaseEntity;
-import lombok.*;
-
-import javax.persistence.*;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+import de.hso.badenair.domain.base.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -15,25 +29,32 @@ import java.time.OffsetDateTime;
 @Table(name = "SCHEDULED_FLIGHT")
 public class ScheduledFlight extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_SCHEDULED_FLIGHT_ID")
-    @SequenceGenerator(name = "GEN_SCHEDULED_FLIGHT", sequenceName = "SEQ_SCHEDULED_FLIGHT")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_SCHEDULED_FLIGHT_ID")
+	@SequenceGenerator(name = "GEN_SCHEDULED_FLIGHT", sequenceName = "SEQ_SCHEDULED_FLIGHT")
+	private Long id;
 
-    @ManyToOne(optional = false)
-    @JoinColumn
-    private Airport startingAirport;
+	@ManyToOne(optional = false)
+	@JoinColumn
+	private Airport startingAirport;
 
-    @ManyToOne(optional = false)
-    @JoinColumn
-    private Airport destinationAirport;
+	@ManyToOne(optional = false)
+	@JoinColumn
+	private Airport destinationAirport;
 
-    @Column(name = "START_TIME")
-    private OffsetDateTime startTime;
+	@Column(name = "START_TIME")
+	private OffsetDateTime startTime;
 
-    @Column(name = "DURATION_IN_HOURS")
-    private Double durationInHours;
+	@Column(name = "DURATION_IN_HOURS")
+	private Double durationInHours;
 
-    @Column(name = "BASE_PRICE")
-    private Double basePrice;
+	@Column(name = "BASE_PRICE")
+	private Double basePrice;
+
+	public OffsetDateTime getStartTime() {
+		if (startTime == null) {
+			return null;
+		}
+		return startTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
 }

--- a/server/src/main/java/de/hso/badenair/domain/schedule/ShiftSchedule.java
+++ b/server/src/main/java/de/hso/badenair/domain/schedule/ShiftSchedule.java
@@ -1,10 +1,22 @@
 package de.hso.badenair.domain.schedule;
 
-import de.hso.badenair.domain.base.BaseEntity;
-import lombok.*;
-
-import javax.persistence.*;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+import de.hso.badenair.domain.base.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -15,17 +27,31 @@ import java.time.OffsetDateTime;
 @Table(name = "SHIFT_SCHEDULE")
 public class ShiftSchedule extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_SHIFT_SCHEDULE_ID")
-    @SequenceGenerator(name = "GEN_SHIFT_SCHEDULE_ID", sequenceName = "SEQ_SHIFT_SCHEDULE")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_SHIFT_SCHEDULE_ID")
+	@SequenceGenerator(name = "GEN_SHIFT_SCHEDULE_ID", sequenceName = "SEQ_SHIFT_SCHEDULE")
+	private Long id;
 
-    @Column(name = "EMPLOYEE_USER_ID")
-    private String employeeUserId;
+	@Column(name = "EMPLOYEE_USER_ID")
+	private String employeeUserId;
 
-    @Column(name = "START_TIME")
-    private OffsetDateTime startTime;
+	@Column(name = "START_TIME")
+	private OffsetDateTime startTime;
 
-    @Column(name = "END_TIME")
-    private OffsetDateTime endTime;
+	@Column(name = "END_TIME")
+	private OffsetDateTime endTime;
+
+	public OffsetDateTime getStartTime() {
+		if (startTime == null) {
+			return null;
+		}
+		return startTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
+
+	public OffsetDateTime getEndTime() {
+		if (endTime == null) {
+			return null;
+		}
+		return endTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
 }

--- a/server/src/main/java/de/hso/badenair/domain/schedule/StandbySchedule.java
+++ b/server/src/main/java/de/hso/badenair/domain/schedule/StandbySchedule.java
@@ -1,10 +1,22 @@
 package de.hso.badenair.domain.schedule;
 
-import de.hso.badenair.domain.base.BaseEntity;
-import lombok.*;
-
-import javax.persistence.*;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+import de.hso.badenair.domain.base.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -15,17 +27,31 @@ import java.time.OffsetDateTime;
 @Table(name = "STANDBY_SCHEDULE")
 public class StandbySchedule extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_STANDBY_SCHEDULE_ID")
-    @SequenceGenerator(name = "GEN_STANDBY_SCHEDULE_ID", sequenceName = "SEQ_STANDBY_SCHEDULE")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_STANDBY_SCHEDULE_ID")
+	@SequenceGenerator(name = "GEN_STANDBY_SCHEDULE_ID", sequenceName = "SEQ_STANDBY_SCHEDULE")
+	private Long id;
 
-    @Column(name = "EMPLOYEE_USER_ID")
-    private String employeeUserId;
+	@Column(name = "EMPLOYEE_USER_ID")
+	private String employeeUserId;
 
-    @Column(name = "START_TIME")
-    private OffsetDateTime startTime;
+	@Column(name = "START_TIME")
+	private OffsetDateTime startTime;
 
-    @Column(name = "END_TIME")
-    private OffsetDateTime endTime;
+	@Column(name = "END_TIME")
+	private OffsetDateTime endTime;
+
+	public OffsetDateTime getStartTime() {
+		if (startTime == null) {
+			return null;
+		}
+		return startTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
+
+	public OffsetDateTime getEndTime() {
+		if (endTime == null) {
+			return null;
+		}
+		return endTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
 }

--- a/server/src/main/java/de/hso/badenair/domain/schedule/Vacation.java
+++ b/server/src/main/java/de/hso/badenair/domain/schedule/Vacation.java
@@ -1,10 +1,22 @@
 package de.hso.badenair.domain.schedule;
 
-import de.hso.badenair.domain.base.BaseEntity;
-import lombok.*;
-
-import javax.persistence.*;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+import de.hso.badenair.domain.base.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -15,19 +27,31 @@ import java.time.OffsetDateTime;
 @Table(name = "VACATION")
 public class Vacation extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_VACATION_ID")
-    @SequenceGenerator(name = "GEN_VACATION_ID", sequenceName = "SEQ_VACATION")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_VACATION_ID")
+	@SequenceGenerator(name = "GEN_VACATION_ID", sequenceName = "SEQ_VACATION")
+	private Long id;
 
-    @Column(name = "EMPLOYEE_USER_ID")
-    private String employeeUserId;
+	@Column(name = "EMPLOYEE_USER_ID")
+	private String employeeUserId;
 
+	@Column(name = "START_TIME")
+	private OffsetDateTime startTime;
 
+	@Column(name = "END_TIME")
+	private OffsetDateTime endTime;
 
-    @Column(name = "START_TIME")
-    private OffsetDateTime startTime;
+	public OffsetDateTime getStartTime() {
+		if (startTime == null) {
+			return null;
+		}
+		return startTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
 
-    @Column(name = "END_TIME")
-    private OffsetDateTime endTime;
+	public OffsetDateTime getEndTime() {
+		if (endTime == null) {
+			return null;
+		}
+		return endTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
 }

--- a/server/src/main/java/de/hso/badenair/domain/schedule/WorkingHours.java
+++ b/server/src/main/java/de/hso/badenair/domain/schedule/WorkingHours.java
@@ -1,10 +1,22 @@
 package de.hso.badenair.domain.schedule;
 
-import de.hso.badenair.domain.base.BaseEntity;
-import lombok.*;
-
-import javax.persistence.*;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+import de.hso.badenair.domain.base.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -15,17 +27,31 @@ import java.time.OffsetDateTime;
 @Table(name = "WORKING_HOURS")
 public class WorkingHours extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_WORKING_HOURS_ID")
-    @SequenceGenerator(name = "GEN_WORKING_HOURS_ID", sequenceName = "SEQ_WORKING_HOURS")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_WORKING_HOURS_ID")
+	@SequenceGenerator(name = "GEN_WORKING_HOURS_ID", sequenceName = "SEQ_WORKING_HOURS")
+	private Long id;
 
-    @Column(name = "EMPLOYEE_USER_ID")
-    private String employeeUserId;
+	@Column(name = "EMPLOYEE_USER_ID")
+	private String employeeUserId;
 
-    @Column(name = "START_TIME")
-    private OffsetDateTime startTime;
+	@Column(name = "START_TIME")
+	private OffsetDateTime startTime;
 
-    @Column(name = "END_TIME")
-    private OffsetDateTime endTime;
+	@Column(name = "END_TIME")
+	private OffsetDateTime endTime;
+
+	public OffsetDateTime getStartTime() {
+		if (startTime == null) {
+			return null;
+		}
+		return startTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
+
+	public OffsetDateTime getEndTime() {
+		if (endTime == null) {
+			return null;
+		}
+		return endTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
 }


### PR DESCRIPTION
Ich habe das Problem bezüglich der Zeitzone in der Datenbank jetzt so gelöst, dass ich die Getter-Methoden der betroffenen Attribute so modifiziert habe, sodass sie immer die Daten in der Zeitzone "+1" zurückgeben. Das war auch die ursprüngliche Annahme, was die Datenbank für die Flugzeiten liefern sollte, da das die BadenAir Zeit ist.
Ausnahme: die zwei Daten in AccountData habe ich nicht geändert, da sie nicht weiter verarbeitet werden und es denke ich mehr Probleme als Profit damit dann gäbe.

Ich denke es ist so wesentlich angenehmer, als wenn wir im Backend mit UTC-Zeit arbeiten müssen. (Zumal es sicher eine weitere mögliche Fehlerquelle für zukünftige Bugs wäre.)
Ich hoffe das passt so. (Oder könnte man das geschickter lösen?)