### PR TITLE
Keine vergangenen Flüge hinzufügen

### DIFF
--- a/server/src/main/java/de/hso/badenair/util/init/StaticDataInitializer.java
+++ b/server/src/main/java/de/hso/badenair/util/init/StaticDataInitializer.java
@@ -248,17 +248,20 @@ public class StaticDataInitializer {
 						// Add flights for the next 12 months
 						if (DateFusioner.fusionStartDate(startDate, scheduledFlight.getStartTime(), null)
 								.isAfter(OffsetDateTime.now().withOffsetSameLocal(ZoneOffset.of("+1")))) {
+							// Flight is in the future
 							flights.add(Flight.builder().scheduledFlight(scheduledFlight).state(FlightState.OK)
 									.plane(plane).startDate(startDate).delay(0.0).build());
 						} else if (DateFusioner
 								.fusionArrivalDate(startDate, scheduledFlight.getStartTime(),
 										Double.valueOf(flightData[3]), null)
 								.isAfter(OffsetDateTime.now().withOffsetSameLocal(ZoneOffset.of("+1")))) {
+							// Plane is flying
 							flights.add(Flight.builder().scheduledFlight(scheduledFlight).state(FlightState.OK)
 									.plane(plane).startDate(startDate).actualStartTime(DateFusioner
 											.fusionStartDate(startDate, scheduledFlight.getStartTime(), null))
 									.delay(0.0).build());
 						} else {
+							// Flight is already finished
 							flights.add(Flight.builder().scheduledFlight(scheduledFlight).state(FlightState.OK)
 									.plane(plane).startDate(startDate)
 									.actualStartTime(DateFusioner.fusionStartDate(startDate,

--- a/server/src/main/java/de/hso/badenair/util/init/StaticDataInitializer.java
+++ b/server/src/main/java/de/hso/badenair/util/init/StaticDataInitializer.java
@@ -38,6 +38,7 @@ import de.hso.badenair.service.plan.vacation.VacationService;
 import de.hso.badenair.service.plane.repository.PlaneRepository;
 import de.hso.badenair.service.plane.repository.PlaneTypeDataRepository;
 import de.hso.badenair.util.csv.CsvHelper;
+import de.hso.badenair.util.time.DateFusioner;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -244,9 +245,13 @@ public class StaticDataInitializer {
 					OffsetDateTime startDate = now
 							.plusDays(Math.floorMod(Integer.valueOf(flightData[5]) - now.getDayOfWeek().getValue(), 7));
 					do {
-						// Add flights for the next 12 months
-						flights.add(Flight.builder().scheduledFlight(scheduledFlight).state(FlightState.OK).plane(plane)
-								.startDate(startDate).build());
+						// Add flights for the next 12 months (excluding flights that started in the
+						// past)
+						if (DateFusioner.fusionStartDate(startDate, scheduledFlight.getStartTime(), null)
+								.isAfter(OffsetDateTime.now().withOffsetSameLocal(ZoneOffset.of("+1")))) {
+							flights.add(Flight.builder().scheduledFlight(scheduledFlight).state(FlightState.OK)
+									.plane(plane).startDate(startDate).build());
+						}
 						startDate = startDate.plusDays(7l);
 					} while (startDate.isBefore(endOfPlanDate));
 				}

--- a/server/src/main/java/de/hso/badenair/util/init/StaticDataInitializer.java
+++ b/server/src/main/java/de/hso/badenair/util/init/StaticDataInitializer.java
@@ -245,12 +245,27 @@ public class StaticDataInitializer {
 					OffsetDateTime startDate = now
 							.plusDays(Math.floorMod(Integer.valueOf(flightData[5]) - now.getDayOfWeek().getValue(), 7));
 					do {
-						// Add flights for the next 12 months (excluding flights that started in the
-						// past)
+						// Add flights for the next 12 months
 						if (DateFusioner.fusionStartDate(startDate, scheduledFlight.getStartTime(), null)
 								.isAfter(OffsetDateTime.now().withOffsetSameLocal(ZoneOffset.of("+1")))) {
 							flights.add(Flight.builder().scheduledFlight(scheduledFlight).state(FlightState.OK)
-									.plane(plane).startDate(startDate).build());
+									.plane(plane).startDate(startDate).delay(0.0).build());
+						} else if (DateFusioner
+								.fusionArrivalDate(startDate, scheduledFlight.getStartTime(),
+										Double.valueOf(flightData[3]), null)
+								.isAfter(OffsetDateTime.now().withOffsetSameLocal(ZoneOffset.of("+1")))) {
+							flights.add(Flight.builder().scheduledFlight(scheduledFlight).state(FlightState.OK)
+									.plane(plane).startDate(startDate).actualStartTime(DateFusioner
+											.fusionStartDate(startDate, scheduledFlight.getStartTime(), null))
+									.delay(0.0).build());
+						} else {
+							flights.add(Flight.builder().scheduledFlight(scheduledFlight).state(FlightState.OK)
+									.plane(plane).startDate(startDate)
+									.actualStartTime(DateFusioner.fusionStartDate(startDate,
+											scheduledFlight.getStartTime(), null))
+									.actualLandingTime(DateFusioner.fusionArrivalDate(startDate,
+											scheduledFlight.getStartTime(), Double.valueOf(flightData[3]), null))
+									.delay(0.0).build());
 						}
 						startDate = startDate.plusDays(7l);
 					} while (startDate.isBefore(endOfPlanDate));


### PR DESCRIPTION
Mein Vorschlag wäre, dass wir die Flüge, die am Initialisierungs-Tag schon gestartet oder vergangen sind nicht hinzufügen, da diese es aus meiner Sicht eher schwieriger machen Verspätungen ordentlich zu behandeln.
Spricht was dagegen oder dafür?

Vielleicht lassen wir den Pull Request auch besser noch eine Zeit offen/ungemerged. Zum Testen kann es unter Umständen ja auch ganz gut sein, wenn ein paar Flüge mehr für den aktuellen Tag da sind.