### PR TITLE
Zeitzonen-Probleme mit Frontend

### DIFF
--- a/frontend-customers/src/app/components/booking-overview/booking-overview.component.html
+++ b/frontend-customers/src/app/components/booking-overview/booking-overview.component.html
@@ -3,9 +3,9 @@
 <div fxLayout="column">
     <h3 *ngIf="toFlight">Hinflug</h3>
     <div fxLayout="row" fxLayoutAlign="space-between center" *ngIf="toFlight">
-        <app-flight-info [time]="toFlight.startTime" [location]="toFlight.start"></app-flight-info>
+        <app-flight-info [time]="toFlight.startTime" [timezone]="toFlight.startTimezone" [location]="toFlight.start"></app-flight-info>
         <p class="duration">{{getDuration(toFlight) | date:'HH:mm'}}</p>
-        <app-flight-info [time]="toFlight.arrivalTime" [location]="toFlight.destination"></app-flight-info>
+        <app-flight-info [time]="toFlight.arrivalTime" [timezone]="toFlight.destinationTimezone" [location]="toFlight.destination"></app-flight-info>
         <ng-container *ngIf="passengers">
             <p class="medium">Passagiere: {{passengers.length}}</p>
             <div class="price">
@@ -16,9 +16,9 @@
     <mat-divider *ngIf="returnFlight"></mat-divider>
     <h3 *ngIf="returnFlight">Rückflug</h3>
     <div fxLayout="row" fxLayoutAlign="space-between center" *ngIf="returnFlight">
-        <app-flight-info [time]="returnFlight.startTime" [location]="returnFlight.start"></app-flight-info>
+        <app-flight-info [time]="returnFlight.startTime" [timezone]="returnFlight.startTimezone" [location]="returnFlight.start"></app-flight-info>
         <p class="duration">{{getDuration(returnFlight) | date:'HH:mm'}}</p>
-        <app-flight-info [time]="returnFlight.arrivalTime" [location]="returnFlight.destination"></app-flight-info>
+        <app-flight-info [time]="returnFlight.arrivalTime" [timezone]="returnFlight.destinationTimezone" [location]="returnFlight.destination"></app-flight-info>
         <ng-container *ngIf="passengers">
             <p class="medium">Passagiere: {{passengers.length}}</p>
             <div class="price">

--- a/frontend-customers/src/app/components/booking-overview/booking-overview.component.html
+++ b/frontend-customers/src/app/components/booking-overview/booking-overview.component.html
@@ -4,7 +4,7 @@
     <h3 *ngIf="toFlight">Hinflug</h3>
     <div fxLayout="row" fxLayoutAlign="space-between center" *ngIf="toFlight">
         <app-flight-info [time]="toFlight.startTime" [timezone]="toFlight.startTimezone" [location]="toFlight.start"></app-flight-info>
-        <p class="duration">{{getDuration(toFlight) | date:'HH:mm'}}</p>
+        <p class="duration">{{getDuration(toFlight)}}</p>
         <app-flight-info [time]="toFlight.arrivalTime" [timezone]="toFlight.destinationTimezone" [location]="toFlight.destination"></app-flight-info>
         <ng-container *ngIf="passengers">
             <p class="medium">Passagiere: {{passengers.length}}</p>
@@ -17,7 +17,7 @@
     <h3 *ngIf="returnFlight">Rückflug</h3>
     <div fxLayout="row" fxLayoutAlign="space-between center" *ngIf="returnFlight">
         <app-flight-info [time]="returnFlight.startTime" [timezone]="returnFlight.startTimezone" [location]="returnFlight.start"></app-flight-info>
-        <p class="duration">{{getDuration(returnFlight) | date:'HH:mm'}}</p>
+        <p class="duration">{{getDuration(returnFlight)}}</p>
         <app-flight-info [time]="returnFlight.arrivalTime" [timezone]="returnFlight.destinationTimezone" [location]="returnFlight.destination"></app-flight-info>
         <ng-container *ngIf="passengers">
             <p class="medium">Passagiere: {{passengers.length}}</p>

--- a/frontend-customers/src/app/components/booking-overview/booking-overview.component.ts
+++ b/frontend-customers/src/app/components/booking-overview/booking-overview.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from '@angular/core';
 
 import { FlightDto, TravelerDto } from 'src/app/services/dtos/Dtos';
 import { Seat } from '../seat-selection/seat-selection.component';
+import { formatDuration } from '../..//services/util/DurationFormatter';
 
 @Component({
   selector: 'app-booking-overview',
@@ -19,10 +20,10 @@ export class BookingOverviewComponent {
 
   getDuration(flight: FlightDto) {
     if (flight) {
-      return flight.arrivalTime.getTime() - flight.startTime.getTime();
+      return formatDuration(flight.arrivalTime.getTime() - flight.startTime.getTime());
     }
 
-    return 0;
+    return "00:00";
   }
 
   convertToSeatNumber(column: number): string {

--- a/frontend-customers/src/app/components/check-in-info/check-in-info.component.html
+++ b/frontend-customers/src/app/components/check-in-info/check-in-info.component.html
@@ -18,7 +18,7 @@
             <button mat-raised-button color="primary" (click)="onDownload()">Download PDF</button>
         </div>
         <div *ngIf="isCheckInComplete && !passenger.checkedIn">
-            <p >Passagier nicht eingecheckt</p>
+            <p>Passagier nicht eingecheckt</p>
         </div>
     </mat-card-content>
 </mat-card>

--- a/frontend-customers/src/app/components/flight/flight-info/flight-info.component.ts
+++ b/frontend-customers/src/app/components/flight/flight-info/flight-info.component.ts
@@ -4,9 +4,9 @@ import {Component, Input} from '@angular/core';
     selector: 'app-flight-info',
     template: `
         <div>
-            <p>{{time | date:'dd.MM.yyyy'}}</p>
+            <p>{{time | date:'dd.MM.yyyy':timezone}}</p>
             <p class="location">{{location}}</p>
-            <p>{{time | date:'HH:mm'}} Uhr</p>
+            <p>{{time | date:'HH:mm':timezone}} Uhr</p>
         </div>
     `,
     styles: [`
@@ -24,5 +24,6 @@ import {Component, Input} from '@angular/core';
 })
 export class FlightInfoComponent {
     @Input() time !: Date;
+    @Input() timezone !: string;
     @Input() location !: string;
 }

--- a/frontend-customers/src/app/components/flight/flight.component.html
+++ b/frontend-customers/src/app/components/flight/flight.component.html
@@ -1,8 +1,8 @@
 <mat-card appHoverClass hoverClass="mat-elevation-z8">
     <mat-card-content>
-        <app-flight-info [time]="flight.startTime" [location]="flight.start"></app-flight-info>
+        <app-flight-info [time]="flight.startTime" [timezone]="flight.startTimezone" [location]="flight.start"></app-flight-info>
         <p class="duration">{{getDuration() | date:'HH:mm'}}</p>
-        <app-flight-info [time]="flight.arrivalTime" [location]="flight.destination"></app-flight-info>
+        <app-flight-info [time]="flight.arrivalTime" [timezone]="flight.destinationTimezone" [location]="flight.destination"></app-flight-info>
         <ng-container *ngIf="!persons">
             <p class="large">Personen: {{numberOfPassengers}}</p>
             <div>

--- a/frontend-customers/src/app/components/flight/flight.component.html
+++ b/frontend-customers/src/app/components/flight/flight.component.html
@@ -1,7 +1,7 @@
 <mat-card appHoverClass hoverClass="mat-elevation-z8">
     <mat-card-content>
         <app-flight-info [time]="flight.startTime" [timezone]="flight.startTimezone" [location]="flight.start"></app-flight-info>
-        <p class="duration">{{getDuration() | date:'HH:mm'}}</p>
+        <p class="duration">{{getDuration()}}</p>
         <app-flight-info [time]="flight.arrivalTime" [timezone]="flight.destinationTimezone" [location]="flight.destination"></app-flight-info>
         <ng-container *ngIf="!persons">
             <p class="large">Personen: {{numberOfPassengers}}</p>

--- a/frontend-customers/src/app/components/flight/flight.component.ts
+++ b/frontend-customers/src/app/components/flight/flight.component.ts
@@ -1,5 +1,6 @@
-import {Component, EventEmitter, Input, Output} from '@angular/core';
-import {FlightDto} from '../../services/dtos/Dtos';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FlightDto } from '../../services/dtos/Dtos';
+import { formatDuration } from '../../services/util/DurationFormatter';
 
 export interface Person {
     name: string;
@@ -47,6 +48,6 @@ export class FlightComponent {
     }
 
     getDuration() {
-        return this.flight.arrivalTime.getTime() - this.flight.startTime.getTime();
+        return formatDuration(this.flight.arrivalTime.getTime() - this.flight.startTime.getTime());
     }
 }

--- a/frontend-customers/src/app/pages/check-in-page/check-in-page.component.html
+++ b/frontend-customers/src/app/pages/check-in-page/check-in-page.component.html
@@ -1,9 +1,9 @@
 <h1>{{ isCheckInComplete ? 'Check-In erfolgreich' : 'Passagiere einchecken' }}</h1>
 <mat-card appHoverClass hoverClass="mat-elevation-z8" *ngIf="flight; else loading">
     <mat-card-content>
-        <app-flight-info [time]="flight.startTime" [location]="flight.start"></app-flight-info>
+        <app-flight-info [time]="flight.startTime" [timezone]="flight.startTimezone" [location]="flight.start"></app-flight-info>
         <p class="duration">{{getDuration() | date:'HH:mm'}}</p>
-        <app-flight-info [time]="flight.arrivalTime" [location]="flight.destination"></app-flight-info>
+        <app-flight-info [time]="flight.arrivalTime" [timezone]="flight.destinationTimezone" [location]="flight.destination"></app-flight-info>
     </mat-card-content>
 </mat-card>
 <p *ngIf="isCheckInComplete">

--- a/frontend-customers/src/app/pages/check-in-page/check-in-page.component.html
+++ b/frontend-customers/src/app/pages/check-in-page/check-in-page.component.html
@@ -2,7 +2,7 @@
 <mat-card appHoverClass hoverClass="mat-elevation-z8" *ngIf="flight; else loading">
     <mat-card-content>
         <app-flight-info [time]="flight.startTime" [timezone]="flight.startTimezone" [location]="flight.start"></app-flight-info>
-        <p class="duration">{{getDuration() | date:'HH:mm'}}</p>
+        <p class="duration">{{getDuration()}}</p>
         <app-flight-info [time]="flight.arrivalTime" [timezone]="flight.destinationTimezone" [location]="flight.destination"></app-flight-info>
     </mat-card-content>
 </mat-card>

--- a/frontend-customers/src/app/pages/check-in-page/check-in-page.component.ts
+++ b/frontend-customers/src/app/pages/check-in-page/check-in-page.component.ts
@@ -3,6 +3,7 @@ import {FlightDto, TravelerDto} from '../../services/dtos/Dtos';
 import {CheckInService} from '../../services/checkin/checkin.service';
 import {ActivatedRoute} from '@angular/router';
 import {InfoService} from '../../services/info/info.service';
+import { formatDuration } from 'src/app/services/util/DurationFormatter';
 
 @Component({
     selector: 'app-check-in-page',
@@ -47,10 +48,10 @@ export class CheckInPageComponent implements OnInit {
 
     getDuration() {
         if (this.flight) {
-            return this.flight.arrivalTime.getTime() - this.flight.startTime.getTime();
+            return formatDuration(this.flight.arrivalTime.getTime() - this.flight.startTime.getTime());
         }
 
-        return 0;
+        return "00:00";
     }
 
     checkIn() {

--- a/frontend-customers/src/app/pages/success-page/success-page.component.html
+++ b/frontend-customers/src/app/pages/success-page/success-page.component.html
@@ -10,6 +10,6 @@
     <mat-card-content>
         <p>Start: {{flight.startTime | date:'dd.MM.yyyy':flight.startTimezone}}, {{flight.startTime | date:'HH:mm:ss':flight.startTimezone}} Uhr</p>
         <p>Landung: {{flight.arrivalTime | date:'dd.MM.yyyy':flight.destinationTimezone}}, {{flight.arrivalTime | date:'HH:mm:ss':flight.destinationTimezone}} Uhr</p>
-        <p>Flugdauer: {{getDuration(flight) | date:'HH:mm'}}</p>
+        <p>Flugdauer: {{getDuration(flight)}}</p>
     </mat-card-content>
 </mat-card>

--- a/frontend-customers/src/app/pages/success-page/success-page.component.html
+++ b/frontend-customers/src/app/pages/success-page/success-page.component.html
@@ -8,8 +8,8 @@
         <p>Ihr Flug von <b>{{flight.start}}</b> nach <b>{{flight.destination}}</b></p>
     </mat-card-header>
     <mat-card-content>
-        <p>Start: {{flight.startTime | date:'dd.MM.yyyy'}}, {{flight.startTime | date:'HH:mm:ss'}} Uhr</p>
-        <p>Landung: {{flight.arrivalTime | date:'dd.MM.yyyy'}}, {{flight.arrivalTime | date:'HH:mm:ss'}} Uhr</p>
+        <p>Start: {{flight.startTime | date:'dd.MM.yyyy':flight.startTimezone}}, {{flight.startTime | date:'HH:mm:ss':flight.startTimezone}} Uhr</p>
+        <p>Landung: {{flight.arrivalTime | date:'dd.MM.yyyy':flight.destinationTimezone}}, {{flight.arrivalTime | date:'HH:mm:ss':flight.destinationTimezone}} Uhr</p>
         <p>Flugdauer: {{getDuration(flight) | date:'HH:mm'}}</p>
     </mat-card-content>
 </mat-card>

--- a/frontend-customers/src/app/pages/success-page/success-page.component.ts
+++ b/frontend-customers/src/app/pages/success-page/success-page.component.ts
@@ -2,6 +2,7 @@ import {Component, OnInit} from '@angular/core';
 import { BookingStateService } from 'src/app/services/search/booking-state.service';
 import { FlightDto } from 'src/app/services/dtos/Dtos';
 import { Subscription } from 'rxjs';
+import { formatDuration } from 'src/app/services/util/DurationFormatter';
 
 
 
@@ -32,7 +33,7 @@ export class SuccessPageComponent implements OnInit{
     }
 
     getDuration(flight: FlightDto): number {
-        return flight.arrivalTime.getTime() - flight.startTime.getTime();
+        return formatDuration(flight.arrivalTime.getTime() - flight.startTime.getTime());
     } 
 
     ngOnDestroy(): void {

--- a/frontend-customers/src/app/pages/success-page/success-page.component.ts
+++ b/frontend-customers/src/app/pages/success-page/success-page.component.ts
@@ -32,7 +32,7 @@ export class SuccessPageComponent implements OnInit{
         });
     }
 
-    getDuration(flight: FlightDto): number {
+    getDuration(flight: FlightDto): string {
         return formatDuration(flight.arrivalTime.getTime() - flight.startTime.getTime());
     } 
 

--- a/frontend-customers/src/app/services/dtos/Dtos.ts
+++ b/frontend-customers/src/app/services/dtos/Dtos.ts
@@ -26,6 +26,8 @@ export interface FlightDto {
     destination: string;
     startTime: Date;
     arrivalTime: Date;
+    startTimezone: string;
+    destinationTimezone: string;
     price: number;
 }
 

--- a/frontend-customers/src/app/services/util/DurationFormatter.ts
+++ b/frontend-customers/src/app/services/util/DurationFormatter.ts
@@ -1,0 +1,6 @@
+export function formatDuration(totalMilliseconds: number) {
+    let hours = Math.trunc(totalMilliseconds / 3600000);
+    let minutes = Math.trunc(totalMilliseconds / 60000 - hours * 60);
+    
+    return hours.toString().padStart(2, "0") + ":" + minutes.toString().padStart(2, "0");
+}

--- a/server/src/main/java/de/hso/badenair/controller/account/AccountController.java
+++ b/server/src/main/java/de/hso/badenair/controller/account/AccountController.java
@@ -39,8 +39,7 @@ public class AccountController {
 	}
 
 	@PutMapping
-	public ResponseEntity<?> updateAccountData(Principal user,
-			@RequestBody @Valid UpdateAccountDataDto dto) {
+	public ResponseEntity<?> updateAccountData(Principal user, @RequestBody @Valid UpdateAccountDataDto dto) {
 		accountService.updateAccountData(user.getName(), dto);
 		return ResponseEntity.ok().build();
 	}
@@ -50,46 +49,35 @@ public class AccountController {
 		List<Booking> bookings = accountService.getBookings(user.getName());
 		List<BookingDto> bookingDtos = bookings.stream().map((booking) -> {
 			// Travelers
-			List<TravelerDto> travelerDtos = booking.getTravelers().stream()
-					.map((traveler) -> {
-						return new TravelerDto(
-								traveler.getFirstName() + " "
-										+ traveler.getLastName(),
-								traveler.getId(), traveler.isCheckedIn());
-					}).collect(Collectors.toList());
+			List<TravelerDto> travelerDtos = booking.getTravelers().stream().map((traveler) -> {
+				return new TravelerDto(traveler.getFirstName() + " " + traveler.getLastName(), traveler.getId(),
+						traveler.isCheckedIn());
+			}).collect(Collectors.toList());
 
 			// Luggage
 			List<LuggageStateDto> luggageDtos = booking.getTravelers().stream()
-					.flatMap(traveler -> traveler.getLuggage() == null
-							? null
-							: traveler.getLuggage().stream())
+					.flatMap(traveler -> traveler.getLuggage() == null ? null : traveler.getLuggage().stream())
 					.map((luggage) -> {
-						return new LuggageStateDto(luggage.getId(),
-								luggage.getState());
+						return new LuggageStateDto(luggage.getId(), luggage.getState());
 					}).collect(Collectors.toList());
 
 			Flight flight = booking.getFlight();
 
 			// Dates
-			OffsetDateTime startDate = DateFusioner.fusionStartDate(
-					flight.getStartDate(),
+			OffsetDateTime startDate = DateFusioner.fusionStartDate(flight.getStartDate(),
 					flight.getScheduledFlight().getStartTime(),
-					flight.getScheduledFlight().getStartingAirport()
-							.getTimezone());
-			OffsetDateTime arrivalDate = DateFusioner.fusionArrivalDate(
-					flight.getStartDate(),
-					flight.getScheduledFlight().getStartTime(),
-					flight.getScheduledFlight().getDurationInHours(),
-					flight.getScheduledFlight().getDestinationAirport()
-							.getTimezone());
+					flight.getScheduledFlight().getStartingAirport().getTimezone());
+			OffsetDateTime arrivalDate = DateFusioner.fusionArrivalDate(flight.getStartDate(),
+					flight.getScheduledFlight().getStartTime(), flight.getScheduledFlight().getDurationInHours(),
+					flight.getScheduledFlight().getDestinationAirport().getTimezone());
 
 			// Create final booking dto
-			return new BookingDto(new FlightDto(flight.getId(),
-					flight.getScheduledFlight().getStartingAirport().getName(),
-					flight.getScheduledFlight().getDestinationAirport()
-							.getName(),
-					startDate, arrivalDate, -1337.0), travelerDtos,
-					luggageDtos);
+			return new BookingDto(
+					new FlightDto(flight.getId(), flight.getScheduledFlight().getStartingAirport().getName(),
+							flight.getScheduledFlight().getDestinationAirport().getName(), startDate, arrivalDate,
+							"UTC" + flight.getScheduledFlight().getStartingAirport().getTimezone(),
+							"UTC" + flight.getScheduledFlight().getDestinationAirport().getTimezone(), -1337.0),
+					travelerDtos, luggageDtos);
 		}).collect(Collectors.toList());
 
 		return ResponseEntity.ok(bookingDtos);

--- a/server/src/main/java/de/hso/badenair/controller/dto/flight/FlightDto.java
+++ b/server/src/main/java/de/hso/badenair/controller/dto/flight/FlightDto.java
@@ -1,15 +1,17 @@
 package de.hso.badenair.controller.dto.flight;
 
-import lombok.Value;
-
 import java.time.OffsetDateTime;
+
+import lombok.Value;
 
 @Value
 public class FlightDto {
-    long id;
-    String start;
-    String destination;
-    OffsetDateTime startTime;
-    OffsetDateTime arrivalTime;
-    double price;
+	long id;
+	String start;
+	String destination;
+	OffsetDateTime startTime;
+	OffsetDateTime arrivalTime;
+	String startTimezone;
+	String destinationTimezone;
+	double price;
 }

--- a/server/src/main/java/de/hso/badenair/controller/plan/PlanController.java
+++ b/server/src/main/java/de/hso/badenair/controller/plan/PlanController.java
@@ -1,5 +1,22 @@
 package de.hso.badenair.controller.plan;
 
+import java.security.Principal;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.stream.Collectors;
+
+import javax.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import de.hso.badenair.controller.dto.plan.RequestVacationDto;
 import de.hso.badenair.controller.dto.plan.ShiftDto;
 import de.hso.badenair.controller.dto.plan.VacationDto;
@@ -9,55 +26,61 @@ import de.hso.badenair.service.plan.PlanService;
 import de.hso.badenair.service.plan.shift.ShiftPlanService;
 import de.hso.badenair.service.plan.vacation.VacationService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import javax.validation.Valid;
-import java.security.Principal;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/employee/plan")
 @RequiredArgsConstructor
 public class PlanController {
 
-    private final PlanService planService;
-    private final VacationService vacationService;
-    private final ShiftPlanService shiftPlanService;
+	private final PlanService planService;
+	private final VacationService vacationService;
+	private final ShiftPlanService shiftPlanService;
 
+	@GetMapping("/shift")
+	public ResponseEntity<List<ShiftDto>> getShiftPlan(Principal user) {
+		final List<ShiftDto> shiftDtos = shiftPlanService.getShiftPlan(user.getName()).stream()
+				.map(shift -> new ShiftDto(
+						shift.getStartTime().withOffsetSameLocal(
+								ZoneOffset.of(TimeZone.getDefault().inDaylightTime(new Date()) ? "+2" : "+1")),
+						shift.getEndTime().withOffsetSameLocal(
+								ZoneOffset.of(TimeZone.getDefault().inDaylightTime(new Date()) ? "+2" : "+1"))))
+				.collect(Collectors.toList());
+		return ResponseEntity.ok(shiftDtos);
+	}
 
-    @GetMapping("/shift")
-    public ResponseEntity<List<ShiftDto>> getShiftPlan(Principal user) {
-        final List<ShiftDto> shiftDtos = shiftPlanService.getShiftPlan(user.getName()).stream()
-            .map(shift -> new ShiftDto(shift.getStartTime(), shift.getEndTime()))
-            .collect(Collectors.toList());
-        return ResponseEntity.ok(shiftDtos);
-    }
+	@GetMapping("/vacation")
+	public ResponseEntity<VacationPlanDto> getVacationPlan(Principal user) {
+		final String userName = user.getName();
+		final List<VacationDto> vacationDtos = vacationService.getVacation(userName).stream()
+				.map(vacation -> new VacationDto(
+						vacation.getStartTime().withOffsetSameLocal(
+								ZoneOffset.of(TimeZone.getDefault().inDaylightTime(new Date()) ? "+2" : "+1")),
+						vacation.getEndTime().withOffsetSameLocal(
+								ZoneOffset.of(TimeZone.getDefault().inDaylightTime(new Date()) ? "+2" : "+1"))))
+				.collect(Collectors.toList());
 
+		final VacationPlanDto dto = new VacationPlanDto(vacationDtos,
+				vacationService.getRemainingVacationDays(userName));
 
-    @GetMapping("/vacation")
-    public ResponseEntity<VacationPlanDto> getVacationPlan(Principal user) {
-        final String userName = user.getName();
-        final List<VacationDto> vacationDtos = vacationService.getVacation(userName).stream()
-            .map(vacation -> new VacationDto(vacation.getStartTime(), vacation.getEndTime()))
-            .collect(Collectors.toList());
+		return ResponseEntity.ok(dto);
+	}
 
-        final VacationPlanDto dto = new VacationPlanDto(vacationDtos, vacationService.getRemainingVacationDays(userName));
+	@PostMapping("/vacation")
+	public ResponseEntity<?> requestVacation(Principal user, @RequestBody @Valid RequestVacationDto dto) {
+		vacationService.requestVacation(user.getName(), dto);
 
-        return ResponseEntity.ok(dto);
-    }
+		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
 
-    @PostMapping("/vacation")
-    public ResponseEntity<?> requestVacation(Principal user, @RequestBody @Valid RequestVacationDto dto) {
-        vacationService.requestVacation(user.getName(), dto);
-
-        return ResponseEntity.status(HttpStatus.CREATED).build();
-    }
-
-    @GetMapping("/standby")
-    public ResponseEntity<List<StandbySchedule>> getStandbyPlan() {
-        return ResponseEntity.ok(this.planService.getStandbyPlan());
-    }
+	@GetMapping("/standby")
+	public ResponseEntity<List<StandbySchedule>> getStandbyPlan() {
+		List<StandbySchedule> standbyScheduleList = this.planService.getStandbyPlan();
+		standbyScheduleList.stream().forEach(standbySchedule -> {
+			standbySchedule.setStartTime(standbySchedule.getStartTime().withOffsetSameLocal(
+					ZoneOffset.of(TimeZone.getDefault().inDaylightTime(new Date()) ? "+2" : "+1")));
+			standbySchedule.setEndTime(standbySchedule.getEndTime().withOffsetSameLocal(
+					ZoneOffset.of(TimeZone.getDefault().inDaylightTime(new Date()) ? "+2" : "+1")));
+		});
+		return ResponseEntity.ok(standbyScheduleList);
+	}
 }

--- a/server/src/main/java/de/hso/badenair/domain/flight/Flight.java
+++ b/server/src/main/java/de/hso/badenair/domain/flight/Flight.java
@@ -1,6 +1,7 @@
 package de.hso.badenair.domain.flight;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Set;
 
 import javax.persistence.CascadeType;
@@ -63,4 +64,25 @@ public class Flight extends BaseEntity {
 
 	@OneToMany(mappedBy = "flight", cascade = CascadeType.ALL, orphanRemoval = true)
 	private Set<Booking> bookings;
+
+	public OffsetDateTime getStartDate() {
+		if (startDate == null) {
+			return null;
+		}
+		return startDate.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
+
+	public OffsetDateTime getActualStartTime() {
+		if (actualStartTime == null) {
+			return null;
+		}
+		return actualStartTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
+
+	public OffsetDateTime getActualLandingTime() {
+		if (actualLandingTime == null) {
+			return null;
+		}
+		return actualLandingTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
 }

--- a/server/src/main/java/de/hso/badenair/domain/flight/ScheduledFlight.java
+++ b/server/src/main/java/de/hso/badenair/domain/flight/ScheduledFlight.java
@@ -1,10 +1,24 @@
 package de.hso.badenair.domain.flight;
 
-import de.hso.badenair.domain.base.BaseEntity;
-import lombok.*;
-
-import javax.persistence.*;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+import de.hso.badenair.domain.base.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -15,25 +29,32 @@ import java.time.OffsetDateTime;
 @Table(name = "SCHEDULED_FLIGHT")
 public class ScheduledFlight extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_SCHEDULED_FLIGHT_ID")
-    @SequenceGenerator(name = "GEN_SCHEDULED_FLIGHT", sequenceName = "SEQ_SCHEDULED_FLIGHT")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_SCHEDULED_FLIGHT_ID")
+	@SequenceGenerator(name = "GEN_SCHEDULED_FLIGHT", sequenceName = "SEQ_SCHEDULED_FLIGHT")
+	private Long id;
 
-    @ManyToOne(optional = false)
-    @JoinColumn
-    private Airport startingAirport;
+	@ManyToOne(optional = false)
+	@JoinColumn
+	private Airport startingAirport;
 
-    @ManyToOne(optional = false)
-    @JoinColumn
-    private Airport destinationAirport;
+	@ManyToOne(optional = false)
+	@JoinColumn
+	private Airport destinationAirport;
 
-    @Column(name = "START_TIME")
-    private OffsetDateTime startTime;
+	@Column(name = "START_TIME")
+	private OffsetDateTime startTime;
 
-    @Column(name = "DURATION_IN_HOURS")
-    private Double durationInHours;
+	@Column(name = "DURATION_IN_HOURS")
+	private Double durationInHours;
 
-    @Column(name = "BASE_PRICE")
-    private Double basePrice;
+	@Column(name = "BASE_PRICE")
+	private Double basePrice;
+
+	public OffsetDateTime getStartTime() {
+		if (startTime == null) {
+			return null;
+		}
+		return startTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
 }

--- a/server/src/main/java/de/hso/badenair/domain/schedule/ShiftSchedule.java
+++ b/server/src/main/java/de/hso/badenair/domain/schedule/ShiftSchedule.java
@@ -1,10 +1,22 @@
 package de.hso.badenair.domain.schedule;
 
-import de.hso.badenair.domain.base.BaseEntity;
-import lombok.*;
-
-import javax.persistence.*;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+import de.hso.badenair.domain.base.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -15,17 +27,31 @@ import java.time.OffsetDateTime;
 @Table(name = "SHIFT_SCHEDULE")
 public class ShiftSchedule extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_SHIFT_SCHEDULE_ID")
-    @SequenceGenerator(name = "GEN_SHIFT_SCHEDULE_ID", sequenceName = "SEQ_SHIFT_SCHEDULE")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_SHIFT_SCHEDULE_ID")
+	@SequenceGenerator(name = "GEN_SHIFT_SCHEDULE_ID", sequenceName = "SEQ_SHIFT_SCHEDULE")
+	private Long id;
 
-    @Column(name = "EMPLOYEE_USER_ID")
-    private String employeeUserId;
+	@Column(name = "EMPLOYEE_USER_ID")
+	private String employeeUserId;
 
-    @Column(name = "START_TIME")
-    private OffsetDateTime startTime;
+	@Column(name = "START_TIME")
+	private OffsetDateTime startTime;
 
-    @Column(name = "END_TIME")
-    private OffsetDateTime endTime;
+	@Column(name = "END_TIME")
+	private OffsetDateTime endTime;
+
+	public OffsetDateTime getStartTime() {
+		if (startTime == null) {
+			return null;
+		}
+		return startTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
+
+	public OffsetDateTime getEndTime() {
+		if (endTime == null) {
+			return null;
+		}
+		return endTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
 }

--- a/server/src/main/java/de/hso/badenair/domain/schedule/StandbySchedule.java
+++ b/server/src/main/java/de/hso/badenair/domain/schedule/StandbySchedule.java
@@ -1,10 +1,22 @@
 package de.hso.badenair.domain.schedule;
 
-import de.hso.badenair.domain.base.BaseEntity;
-import lombok.*;
-
-import javax.persistence.*;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+import de.hso.badenair.domain.base.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -15,17 +27,31 @@ import java.time.OffsetDateTime;
 @Table(name = "STANDBY_SCHEDULE")
 public class StandbySchedule extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_STANDBY_SCHEDULE_ID")
-    @SequenceGenerator(name = "GEN_STANDBY_SCHEDULE_ID", sequenceName = "SEQ_STANDBY_SCHEDULE")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_STANDBY_SCHEDULE_ID")
+	@SequenceGenerator(name = "GEN_STANDBY_SCHEDULE_ID", sequenceName = "SEQ_STANDBY_SCHEDULE")
+	private Long id;
 
-    @Column(name = "EMPLOYEE_USER_ID")
-    private String employeeUserId;
+	@Column(name = "EMPLOYEE_USER_ID")
+	private String employeeUserId;
 
-    @Column(name = "START_TIME")
-    private OffsetDateTime startTime;
+	@Column(name = "START_TIME")
+	private OffsetDateTime startTime;
 
-    @Column(name = "END_TIME")
-    private OffsetDateTime endTime;
+	@Column(name = "END_TIME")
+	private OffsetDateTime endTime;
+
+	public OffsetDateTime getStartTime() {
+		if (startTime == null) {
+			return null;
+		}
+		return startTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
+
+	public OffsetDateTime getEndTime() {
+		if (endTime == null) {
+			return null;
+		}
+		return endTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
 }

--- a/server/src/main/java/de/hso/badenair/domain/schedule/Vacation.java
+++ b/server/src/main/java/de/hso/badenair/domain/schedule/Vacation.java
@@ -1,10 +1,22 @@
 package de.hso.badenair.domain.schedule;
 
-import de.hso.badenair.domain.base.BaseEntity;
-import lombok.*;
-
-import javax.persistence.*;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+import de.hso.badenair.domain.base.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -15,19 +27,31 @@ import java.time.OffsetDateTime;
 @Table(name = "VACATION")
 public class Vacation extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_VACATION_ID")
-    @SequenceGenerator(name = "GEN_VACATION_ID", sequenceName = "SEQ_VACATION")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_VACATION_ID")
+	@SequenceGenerator(name = "GEN_VACATION_ID", sequenceName = "SEQ_VACATION")
+	private Long id;
 
-    @Column(name = "EMPLOYEE_USER_ID")
-    private String employeeUserId;
+	@Column(name = "EMPLOYEE_USER_ID")
+	private String employeeUserId;
 
+	@Column(name = "START_TIME")
+	private OffsetDateTime startTime;
 
+	@Column(name = "END_TIME")
+	private OffsetDateTime endTime;
 
-    @Column(name = "START_TIME")
-    private OffsetDateTime startTime;
+	public OffsetDateTime getStartTime() {
+		if (startTime == null) {
+			return null;
+		}
+		return startTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
 
-    @Column(name = "END_TIME")
-    private OffsetDateTime endTime;
+	public OffsetDateTime getEndTime() {
+		if (endTime == null) {
+			return null;
+		}
+		return endTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
 }

--- a/server/src/main/java/de/hso/badenair/domain/schedule/WorkingHours.java
+++ b/server/src/main/java/de/hso/badenair/domain/schedule/WorkingHours.java
@@ -1,10 +1,22 @@
 package de.hso.badenair.domain.schedule;
 
-import de.hso.badenair.domain.base.BaseEntity;
-import lombok.*;
-
-import javax.persistence.*;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+import de.hso.badenair.domain.base.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -15,17 +27,31 @@ import java.time.OffsetDateTime;
 @Table(name = "WORKING_HOURS")
 public class WorkingHours extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_WORKING_HOURS_ID")
-    @SequenceGenerator(name = "GEN_WORKING_HOURS_ID", sequenceName = "SEQ_WORKING_HOURS")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GEN_WORKING_HOURS_ID")
+	@SequenceGenerator(name = "GEN_WORKING_HOURS_ID", sequenceName = "SEQ_WORKING_HOURS")
+	private Long id;
 
-    @Column(name = "EMPLOYEE_USER_ID")
-    private String employeeUserId;
+	@Column(name = "EMPLOYEE_USER_ID")
+	private String employeeUserId;
 
-    @Column(name = "START_TIME")
-    private OffsetDateTime startTime;
+	@Column(name = "START_TIME")
+	private OffsetDateTime startTime;
 
-    @Column(name = "END_TIME")
-    private OffsetDateTime endTime;
+	@Column(name = "END_TIME")
+	private OffsetDateTime endTime;
+
+	public OffsetDateTime getStartTime() {
+		if (startTime == null) {
+			return null;
+		}
+		return startTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
+
+	public OffsetDateTime getEndTime() {
+		if (endTime == null) {
+			return null;
+		}
+		return endTime.withOffsetSameInstant(ZoneOffset.of("+1"));
+	}
 }

--- a/server/src/main/java/de/hso/badenair/service/workinghours/WorkingHoursService.java
+++ b/server/src/main/java/de/hso/badenair/service/workinghours/WorkingHoursService.java
@@ -1,49 +1,49 @@
 package de.hso.badenair.service.workinghours;
 
-import de.hso.badenair.domain.schedule.WorkingHours;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import de.hso.badenair.domain.schedule.WorkingHours;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class WorkingHoursService {
 
-    private final WorkingHoursRepository workingHoursRepository;
+	private final WorkingHoursRepository workingHoursRepository;
 
-    public WorkingHours triggerWorkingHours(String employeeUserId) {
-        Optional<WorkingHours> latestWorkingHours = getLatestWorkingHours(employeeUserId);
+	public WorkingHours triggerWorkingHours(String employeeUserId) {
+		Optional<WorkingHours> latestWorkingHours = getLatestWorkingHours(employeeUserId);
 
-        if(latestWorkingHours.isEmpty() || latestWorkingHours.get().getEndTime() != null) {
-            WorkingHours workingHours = WorkingHours.builder()
-                .employeeUserId(employeeUserId)
-                .startTime(OffsetDateTime.now())
-                .endTime(null)
-                .build();
+		if (latestWorkingHours.isEmpty() || latestWorkingHours.get().getEndTime() != null) {
+			WorkingHours workingHours = WorkingHours.builder().employeeUserId(employeeUserId)
+					.startTime(OffsetDateTime.now().withOffsetSameLocal(ZoneOffset.of("+1"))).endTime(null).build();
 
-            workingHoursRepository.save(workingHours);
+			workingHoursRepository.save(workingHours);
 
-            return workingHours;
-        } else {
-            latestWorkingHours.get().setEndTime(OffsetDateTime.now());
-            workingHoursRepository.save(latestWorkingHours.get());
+			return workingHours;
+		} else {
+			latestWorkingHours.get().setEndTime(OffsetDateTime.now().withOffsetSameLocal(ZoneOffset.of("+1")));
+			workingHoursRepository.save(latestWorkingHours.get());
 
-            return latestWorkingHours.get();
-        }
-    }
+			return latestWorkingHours.get();
+		}
+	}
 
-    public Optional<WorkingHours> getLatestWorkingHours(String employeeUserId) {
-        Optional<WorkingHours> workingHours = Optional.empty();
+	public Optional<WorkingHours> getLatestWorkingHours(String employeeUserId) {
+		Optional<WorkingHours> workingHours = Optional.empty();
 
-        List<WorkingHours> employeeWorkingHours = workingHoursRepository.findByEmployeeUserIdOrderByStartTimeDesc(employeeUserId);
+		List<WorkingHours> employeeWorkingHours = workingHoursRepository
+				.findByEmployeeUserIdOrderByStartTimeDesc(employeeUserId);
 
-        if(employeeWorkingHours.size() != 0) {
-            workingHours = Optional.of(employeeWorkingHours.get(0));
-        }
+		if (employeeWorkingHours.size() != 0) {
+			workingHours = Optional.of(employeeWorkingHours.get(0));
+		}
 
-        return workingHours;
-    }
+		return workingHours;
+	}
 }

--- a/server/src/main/java/de/hso/badenair/util/mapper/FlightMapper.java
+++ b/server/src/main/java/de/hso/badenair/util/mapper/FlightMapper.java
@@ -1,50 +1,38 @@
 package de.hso.badenair.util.mapper;
 
+import java.time.OffsetDateTime;
+
 import de.hso.badenair.controller.dto.flight.FlightDto;
 import de.hso.badenair.controller.flight.PriceCalculator;
 import de.hso.badenair.domain.booking.Booking;
 import de.hso.badenair.domain.flight.Flight;
 import de.hso.badenair.util.time.DateFusioner;
 
-import java.time.OffsetDateTime;
-
 public abstract class FlightMapper {
 
-    /**
-     * @param flight Flight to map to the corresponding dto
-     * @return Returns the mapped dto
-     */
-    public static FlightDto mapToDto(Flight flight) {
-        int takenSeats = 0;
-        for (Booking booking : flight.getBookings()) {
-            takenSeats += booking.getTravelers().size();
-        }
+	/**
+	 * @param flight Flight to map to the corresponding dto
+	 * @return Returns the mapped dto
+	 */
+	public static FlightDto mapToDto(Flight flight) {
+		int takenSeats = 0;
+		for (Booking booking : flight.getBookings()) {
+			takenSeats += booking.getTravelers().size();
+		}
 
-        // Dates
-        OffsetDateTime startDate = DateFusioner
-            .fusionStartDate(flight.getStartDate(),
-                flight.getScheduledFlight().getStartTime(),
-                flight.getScheduledFlight()
-                    .getStartingAirport()
-                    .getTimezone());
-        OffsetDateTime arrivalDate = DateFusioner.fusionArrivalDate(
-            flight.getStartDate(),
-            flight.getScheduledFlight().getStartTime(),
-            flight.getScheduledFlight().getDurationInHours(),
-            flight.getScheduledFlight().getStartingAirport()
-                .getTimezone());
+		// Dates
+		OffsetDateTime startDate = DateFusioner.fusionStartDate(flight.getStartDate(),
+				flight.getScheduledFlight().getStartTime(),
+				flight.getScheduledFlight().getStartingAirport().getTimezone());
+		OffsetDateTime arrivalDate = DateFusioner.fusionArrivalDate(flight.getStartDate(),
+				flight.getScheduledFlight().getStartTime(), flight.getScheduledFlight().getDurationInHours(),
+				flight.getScheduledFlight().getStartingAirport().getTimezone());
 
-        return new FlightDto(flight.getId(),
-            flight.getScheduledFlight().getStartingAirport()
-                .getName(),
-            flight.getScheduledFlight().getDestinationAirport()
-                .getName(),
-            startDate, arrivalDate,
-            PriceCalculator.calcFlightPriceRaw(
-                flight.getScheduledFlight().getBasePrice(),
-                takenSeats,
-                flight.getPlane().getTypeData()
-                    .getNumberOfPassengers(),
-                startDate));
-    }
+		return new FlightDto(flight.getId(), flight.getScheduledFlight().getStartingAirport().getName(),
+				flight.getScheduledFlight().getDestinationAirport().getName(), startDate, arrivalDate,
+				"UTC" + flight.getScheduledFlight().getStartingAirport().getTimezone(),
+				"UTC" + flight.getScheduledFlight().getDestinationAirport().getTimezone(),
+				PriceCalculator.calcFlightPriceRaw(flight.getScheduledFlight().getBasePrice(), takenSeats,
+						flight.getPlane().getTypeData().getNumberOfPassengers(), startDate));
+	}
 }


### PR DESCRIPTION
Für die Flüge wird nun die Zeitzone mitgesendet. Beim Anzeigen wird dann die Zeitzone mitgegeben, sodass die Zeit korrekt angezeigt wird.
Für die falsch angezeigten Zeitdauern: ich vermute, dass etwas nicht ganz stimmt, wenn man eine Zeitdauer als Datum formatiert... entsprechend habe ich das jetzt etwas unschöner gelöst. Ich denke zum aktuellen Zeitpunkt können wir uns inzwischen sowas erlauben ;)
Auf der Employee-Seite habe ich die möglichen zukünftigen Probleme jetzt so gelöst, dass ich schon im Backend die Zeitzone anpasse. Der Code-Schnipsel ist etwas lang und jetzt an mehreren Stellen eingefügt. Ich hoffe, dass auch das nicht allzu hässlich ist. Gleichwertig habe ich übrigens auch mit den Commits 31044f78843e52a16679d2ad186f5bebac4bb7b1 und fd83b67409e0d4668cb3fc4509549921d1ebfe3d für die Start/Landung und den Flugplan dieses Problem gelöst (allerdings auf den jeweiligen Branches). Ich hoffe das passt soweit auch.